### PR TITLE
dev環境をローカルから作成

### DIFF
--- a/env/dev/.terraform.lock.hcl
+++ b/env/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.8.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
+    "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
+    "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
+    "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",
+    "zh:4ad1f8ef5c5522f81d271b93594a43a7666b3409ca201a1911cd950e489ef12b",
+    "zh:540a50ab7061c6df2057ec9580890a9e86a687233120af738985fa84dde2a20a",
+    "zh:6e7b73b770e92891da94751c3e0cff1e1b852f5121da8c4a689056833eeb7d94",
+    "zh:879d42721e86331b05ff77bd219ca9a062485cdb2fa803d2dcf63084f25d484c",
+    "zh:980563e615fbba127c02df6dc8872ce60f7137df45fdb8cd801cdcbae6cf192a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6ad25c4d3edde466ea68731097aedad4b68278af0742fc1ab71d2c30491f92e",
+    "zh:af8df9e06f576c11ce67ac2b675d0d8db4aac618fec95d27c10aa59436feebbf",
+    "zh:b625ca7c4b99c6b3af34041b9773ccd9d80b0dde264c40b5d163a6abd73793af",
+    "zh:c9e0ca6aa48ebaa0892ac438392c49052a86605f490950d5317855f35ab7d74a",
+    "zh:dc500a03d3ed6b1fed3f118a55a7fb93bf172965ae6b2f25cc7f4a152e44edd7",
+    "zh:e0438bf67d93a29f0d56f9a4544297155ca85c0f10626778d4c3aa68c7e93581",
+  ]
+}

--- a/env/dev/.terraform.lock.hcl
+++ b/env/dev/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.8.0"
-  constraints = "~> 5.0"
+  constraints = ">= 4.9.0, >= 4.59.0, ~> 5.0"
   hashes = [
     "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
     "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",

--- a/env/dev/backend.tf
+++ b/env/dev/backend.tf
@@ -1,9 +1,9 @@
-# terraform {
-#   backend "s3" {
-#     bucket = "dev-bucket-architecture-s3-bucket"
-#     key    = "dev/terraform.tfstate"
-#     region = "ap-northeast-1"
-#     # dynamodb_table = "set_dev_dynamo_db"
-#     encrypt = true
-#   }
-# }
+terraform {
+  backend "s3" {
+    bucket         = "dev-bucket-architecture-s3-bucket"
+    key            = "dev/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "set_dev_dynamo_db"
+    encrypt        = true
+  }
+}

--- a/env/dev/backend.tf
+++ b/env/dev/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "dev-bucket-architecture-s3-bucket"
+    key     = "dev/terraform.tfstate"
+    region  = "ap-northeast-1"
+    encrypt = true
+  }
+}

--- a/env/dev/backend.tf
+++ b/env/dev/backend.tf
@@ -1,8 +1,9 @@
-terraform {
-  backend "s3" {
-    bucket  = "dev-bucket-architecture-s3-bucket"
-    key     = "dev/terraform.tfstate"
-    region  = "ap-northeast-1"
-    encrypt = true
-  }
-}
+# terraform {
+#   backend "s3" {
+#     bucket = "dev-bucket-architecture-s3-bucket"
+#     key    = "dev/terraform.tfstate"
+#     region = "ap-northeast-1"
+#     # dynamodb_table = "set_dev_dynamo_db"
+#     encrypt = true
+#   }
+# }

--- a/env/dev/locals.tf
+++ b/env/dev/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  dev_tfstate_s3 = {
+    acl           = "private"
+    sse_algorithm = "AES256"
+  }
+  dev_tfstate_dynamodb = {
+    hash_key = "LockID"
+  }
+}

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -1,0 +1,3 @@
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/24"
+}

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -1,3 +1,7 @@
 resource "aws_vpc" "this" {
   cidr_block = "10.0.0.0/24"
 }
+
+module "dev_tfstate_s3" {
+  source = "../../modules/dev_tfstate_s3"
+}

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -2,6 +2,6 @@ resource "aws_vpc" "this" {
   cidr_block = "10.0.0.0/24"
 }
 
-module "dev_tfstate_s3" {
-  source = "../../modules/dev_tfstate_s3"
+module "dev_tfstate" {
+  source = "../../modules/dev_tfstate"
 }

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -2,6 +2,9 @@ resource "aws_vpc" "this" {
   cidr_block = "10.0.0.0/24"
 }
 
-module "dev_tfstate" {
-  source = "../../modules/dev_tfstate"
+module "dev_tfstate" { # tfstateを管理するリソースを作成 S3, DynamoDB
+  source        = "../../modules/dev_tfstate"
+  acl           = local.dev_tfstate_s3.acl
+  sse_algorithm = local.dev_tfstate_s3.sse_algorithm
+  hash_key      = local.dev_tfstate_dynamodb.hash_key
 }

--- a/env/dev/provider.tf
+++ b/env/dev/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "1.3.9"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/env/dev/provider.tf
+++ b/env/dev/provider.tf
@@ -10,4 +10,9 @@ terraform {
 
 provider "aws" {
   region = "ap-northeast-1"
+  default_tags {
+    tags = {
+      Environment = "dev"
+    }
+  }
 }

--- a/modules/dev_tfstate/main.tf
+++ b/modules/dev_tfstate/main.tf
@@ -2,7 +2,7 @@ module "s3_bucket_dev_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
 
   bucket = "dev-bucket-architecture-s3-bucket"
-  acl    = "private"
+  acl    = var.acl
 
   control_object_ownership = true
   object_ownership         = "ObjectWriter"
@@ -13,7 +13,7 @@ module "s3_bucket_dev_bucket" {
   server_side_encryption_configuration = {
     rule = {
       apply_server_side_encryption_by_default = {
-        sse_algorithm = "AES256"
+        sse_algorithm = var.sse_algorithm
       }
     }
   }
@@ -27,13 +27,13 @@ module "dynamodb_table" {
   source                         = "terraform-aws-modules/dynamodb-table/aws"
   name                           = "set_dev_dynamo_db"
   billing_mode                   = "PAY_PER_REQUEST"
-  hash_key                       = "LockID"
+  hash_key                       = var.hash_key
   server_side_encryption_enabled = true
   point_in_time_recovery_enabled = true
 
   attributes = [
     {
-      name = "LockID"
+      name = var.hash_key
       type = "S"
     }
   ]

--- a/modules/dev_tfstate/main.tf
+++ b/modules/dev_tfstate/main.tf
@@ -22,3 +22,19 @@ module "s3_bucket_dev_bucket" {
     name = "dev-bucket-architecture-s3-bucket"
   }
 }
+
+module "dynamodb_table" {
+  source                         = "terraform-aws-modules/dynamodb-table/aws"
+  name                           = "set_dev_dynamo_db"
+  billing_mode                   = "PAY_PER_REQUEST"
+  hash_key                       = "LockID"
+  server_side_encryption_enabled = true
+  point_in_time_recovery_enabled = true
+
+  attributes = [
+    {
+      name = "LockID"
+      type = "S"
+    }
+  ]
+}

--- a/modules/dev_tfstate/variables.tf
+++ b/modules/dev_tfstate/variables.tf
@@ -1,0 +1,17 @@
+variable "acl" {
+  description = "The canned ACL to apply. Defaults to 'private'."
+  type        = string
+  default     = "private"
+}
+
+variable "sse_algorithm" {
+  description = "The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`."
+  type        = string
+  default     = "AES256"
+}
+
+variable "hash_key" {
+  description = "The attribute to use as the hash (partition) key. Must also be defined as an attribute."
+  type        = string
+  default     = "LockID"
+}

--- a/modules/dev_tfstate_s3/main.tf
+++ b/modules/dev_tfstate_s3/main.tf
@@ -1,0 +1,24 @@
+module "s3_bucket_dev_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  bucket = "dev-bucket-architecture-s3-bucket"
+  acl    = "private"
+
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
+  versioning = {
+    enabled = true
+  }
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = {
+    name = "dev-bucket-architecture-s3-bucket"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,26 @@
 ## ディレクトリ構成
 ```console
 .
-├── ./modules # AWSのリソースを作成する
-│   ├── ./modules/oidc # OIDCを作成
-│   │   ├── ./modules/oidc/main.tf
-│   │   ├── ./modules/oidc/outputs.tf
-│   │   └── ./modules/oidc/variables.tf
-│   └── ./modules/s3　＃ S3バケットを作成
-│       ├── ./modules/s3/main.tf
-│       ├── ./modules/s3/outputs.tf
-│       └── ./modules/s3/variables.tf
-├── ./prepare # 共通のAWSリソースを作成
-│   ├── ./prepare/backend.tf
-│   ├── ./prepare/main.tf
-│   ├── ./prepare/provider.tf
-│   └── ./prepare/variables.tf
-└── ./readme.md
+├── env # 環境
+│   └── dev # 開発環境
+│       ├── main.tf # devで使用するAWSのリソースを構築
+│       ├── provider.tf # terraformの設定
+│       └── variables.tf # dev環境で使用するvariable一覧
+├── modules # 呼び出すリソースを作成
+│   ├── oidc # OIDC周りのリソース
+│   │   ├── main.tf # OIDCを作成するのに必要なAWSリソース
+│   │   ├── outputs.tf # OIDCで外部から呼び出す時に使用
+│   │   └── variables.tf # OIDCディレクトリ内で使用するvariables一覧
+│   └── s3 # S3バケットを作成
+│       ├── main.tf # S3を作成するのに必要なAWSリソース
+│       ├── outputs.tf # S3で外部から呼び出す時に使用
+│       └── variables.tf # S3ディレクトリ内で使用するvariables一覧
+├── prepare # 共通リソースを作成 環境によらず作成するリソース
+│   ├── backend.tf # tfstateを管理
+│   ├── main.tf #  # 共通リソースで使用するAWSのリソースを構築
+│   ├── provider.tf # terraformの設定
+│   └── variables.tf # 共通環境で使用するvariable一覧
+└── readme.md # ディレクトリ内の説明
 ```
 
 ## 実装方法
@@ -35,11 +40,6 @@
   - main.tf, variables.tf, outputs.tf, locals.tfは空でも作成する
   - readmeで各のmodule内で作成されるリソースとリソースの用途を明記
   - variable, outputにはdescriptionとtypeを追加する
-- developにmergeするときはSquash and mergeを採用
-- mainにmergeするときはmerge commitを採用
-
-## ディレクトリ説明
-随時更新
 
 ## tfsec
 terraformで作成したリソースを、AWSのベストプラクティスの観点からセキュリティを分析するツール https://github.com/aquasecurity/tfsec


### PR DESCRIPTION
## 目的
- dev環境をローカルから作成する

## 実装内容
- provider.tfでterraformブロックを作成
- tfstateをs3とdynamoDBで作成
- 設定値を環境変数で管理

## 動作確認
- [x] VPCのみ作成し、リソースが作成されるかコンソール画面から確認
- [x] tfstateがS3で管理されているか確認
- [x] dynamoDBで書き込みされているか確認

## 参考文献
