### PR TITLE
dev環境にtfsecを導入

### DIFF
--- a/.github/workflows/dev_tfsec.yml
+++ b/.github/workflows/dev_tfsec.yml
@@ -1,0 +1,43 @@
+name: Terraform Security Scan
+
+on:
+  push:
+    branches:
+      - feature/*
+      - hotfix/*
+
+jobs:
+  tfsec:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.19.2
+
+    - name: Install tfsec
+      run: go install github.com/aquasecurity/tfsec/cmd/tfsec@v1.28.1
+
+    - name: Install jq
+      run: sudo apt-get install jq
+
+    - name: Show Result tfsec
+      run: tfsec ./envs/dev || true
+
+    - name: Run tfsec
+      run: tfsec ./envs/dev --format json > tfsec_output.json || true
+
+    - name: Check tfsec results
+      run: |
+        critical_count=$(jq '[.results[] | select(.severity == "CRITICAL")] | length' tfsec_output.json)
+        high_count=$(jq '[.results[] | select(.severity == "HIGH")] | length' tfsec_output.json)
+        if [ $critical_count -eq 0 ] && [ $high_count -eq 0 ]; then
+          echo "No critical or high findings, CI passes."
+          exit 0
+        else
+          echo "Critical or high findings detected, CI fails."
+          exit 1
+        fi

--- a/.github/workflows/dev_tfsec.yml
+++ b/.github/workflows/dev_tfsec.yml
@@ -1,4 +1,4 @@
-name: Terraform Security Scan
+name: dev環境にtfsec
 
 on:
   push:

--- a/envs/dev/.tfsec/config.yml
+++ b/envs/dev/.tfsec/config.yml
@@ -1,0 +1,3 @@
+exclude:
+  # S3に対して、pushされた記録を取るS3
+  - aws-s3-enable-bucket-logging


### PR DESCRIPTION
## 目的
- tfsecを導入して、AWSのベストプラクティスの観点からセキュリティを検証する

## 実装内容
- dev環境に対して、pushするたびにtfsecを検証するCIを作成
- 危険レベルがcriticalかhighがあった場合、CIが通らない
- 危険レベルがcriticalかhighがない場合、CIは通る

## 動作確認
- [x] dev環境にtfsecを導入 [Actions](https://github.com/hikobend/aws-sample-architecture-1/actions/runs/5633886852)

## 参考文献
- [tfsecのgithub](https://github.com/aquasecurity/tfsec)