### PR TITLE
EC2回りのリソースをTerraformで作成

### DIFF
--- a/envs/dev/.tfsec/config.yml
+++ b/envs/dev/.tfsec/config.yml
@@ -3,3 +3,6 @@ exclude:
   - aws-ec2-require-vpc-flow-logs-for-all-vpcs
   - aws-ec2-no-public-egress-sgr
   - aws-ec2-no-public-ingress-sgr
+  - aws-elb-http-not-used
+  - aws-elb-alb-not-public
+  - aws-s3-enable-bucket-encryption

--- a/envs/dev/.tfsec/config.yml
+++ b/envs/dev/.tfsec/config.yml
@@ -5,4 +5,3 @@ exclude:
   - aws-ec2-no-public-ingress-sgr
   - aws-elb-http-not-used
   - aws-elb-alb-not-public
-  - aws-s3-enable-bucket-encryption

--- a/envs/dev/locals.tf
+++ b/envs/dev/locals.tf
@@ -12,4 +12,11 @@ locals {
     public_subnets  = ["10.0.0.0/26", "10.0.0.64/26"]
     private_subnets = ["10.0.0.128/26", "10.0.0.192/26"]
   }
+  ec2 = {
+    user_data = <<-EOF
+    #!/bin/bash
+    yum update -y
+    amazon-linux-extras install docker -y
+    EOF
+  }
 }

--- a/envs/dev/locals.tf
+++ b/envs/dev/locals.tf
@@ -12,11 +12,19 @@ locals {
     public_subnets  = ["10.0.0.0/26", "10.0.0.64/26"]
     private_subnets = ["10.0.0.128/26", "10.0.0.192/26"]
   }
+  alb = {
+    target_type = "instance"
+  }
   ec2 = {
-    user_data = <<-EOF
+    instance_type = "t2.micro"
+    ami           = "ami-0329eac6c5240c99d"
+    user_data     = <<-EOF
     #!/bin/bash
     yum update -y
     amazon-linux-extras install docker -y
     EOF
+  }
+  s3 = {
+    alb_access_log_bucket_acl = "log-delivery-write"
   }
 }

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -16,6 +16,7 @@ module "network" {
 
 module "ec2" {
   source               = "../../modules/ec2"
+  user_data            = local.ec2.user_data
   vpc_id               = module.network.vpc_id
   public_subnet_1a_id  = module.network.public_subnet_1a_id
   public_subnet_1c_id  = module.network.public_subnet_1c_id

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -13,3 +13,12 @@ module "network" {
   private_subnets = local.network.private_subnets
   env             = var.env
 }
+
+module "ec2" {
+  source              = "../../modules/ec2"
+  vpc_id              = module.network.vpc_id
+  public_subnet_1a_id = module.network.public_subnet_1a_id
+  public_subnet_1c_id = module.network.public_subnet_1c_id
+  alb_sg              = module.network.alb_sg
+  env                 = var.env
+}

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -21,7 +21,9 @@ module "ec2" {
   public_subnet_1a_id       = module.network.public_subnet_1a_id
   public_subnet_1c_id       = module.network.public_subnet_1c_id
   private_subnet_1a_id      = module.network.private_subnet_1a_id
+  private_subnet_1c_id      = module.network.private_subnet_1c_id
   availability_zone_1a      = module.network.availability_zone_1a
+  availability_zone_1c      = module.network.availability_zone_1c
   alb_sg                    = module.network.alb_sg
   application_sg            = module.network.application_sg
   ssm_sg                    = module.network.ssm_sg

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -15,15 +15,19 @@ module "network" {
 }
 
 module "ec2" {
-  source               = "../../modules/ec2"
-  user_data            = local.ec2.user_data
-  vpc_id               = module.network.vpc_id
-  public_subnet_1a_id  = module.network.public_subnet_1a_id
-  public_subnet_1c_id  = module.network.public_subnet_1c_id
-  private_subnet_1a_id = module.network.private_subnet_1a_id
-  availability_zone_1a = module.network.availability_zone_1a
-  alb_sg               = module.network.alb_sg
-  application_sg       = module.network.application_sg
-  ssm_sg               = module.network.ssm_sg
-  env                  = var.env
+  source                    = "../../modules/ec2"
+  user_data                 = local.ec2.user_data
+  vpc_id                    = module.network.vpc_id
+  public_subnet_1a_id       = module.network.public_subnet_1a_id
+  public_subnet_1c_id       = module.network.public_subnet_1c_id
+  private_subnet_1a_id      = module.network.private_subnet_1a_id
+  availability_zone_1a      = module.network.availability_zone_1a
+  alb_sg                    = module.network.alb_sg
+  application_sg            = module.network.application_sg
+  ssm_sg                    = module.network.ssm_sg
+  target_type               = local.alb.target_type
+  instance_type             = local.ec2.instance_type
+  ami                       = local.ec2.ami
+  alb_access_log_bucket_acl = local.s3.alb_access_log_bucket_acl
+  env                       = var.env
 }

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -15,10 +15,14 @@ module "network" {
 }
 
 module "ec2" {
-  source              = "../../modules/ec2"
-  vpc_id              = module.network.vpc_id
-  public_subnet_1a_id = module.network.public_subnet_1a_id
-  public_subnet_1c_id = module.network.public_subnet_1c_id
-  alb_sg              = module.network.alb_sg
-  env                 = var.env
+  source               = "../../modules/ec2"
+  vpc_id               = module.network.vpc_id
+  public_subnet_1a_id  = module.network.public_subnet_1a_id
+  public_subnet_1c_id  = module.network.public_subnet_1c_id
+  private_subnet_1a_id = module.network.private_subnet_1a_id
+  availability_zone_1a = module.network.availability_zone_1a
+  alb_sg               = module.network.alb_sg
+  application_sg       = module.network.application_sg
+  ssm_sg               = module.network.ssm_sg
+  env                  = var.env
 }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -50,9 +50,13 @@ module "alb_access_log_bucket" {
   object_ownership               = "ObjectWriter"
   attach_elb_log_delivery_policy = true
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
+  versioning = {
+    enabled = true
+  }
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
         sse_algorithm = "AES256"
       }
     }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -47,7 +47,7 @@ module "ec2_instance_1a" {
   vpc_security_group_ids = [var.application_sg, var.ssm_sg]
   subnet_id              = var.private_subnet_1a_id
   availability_zone      = var.availability_zone_1a
-  iam_instance_profile   = aws_iam_instance_profile.EC2_enable_SSM_connect_instance_profile.arn
+  iam_instance_profile   = aws_iam_instance_profile.EC2_enable_SSM_connect_instance_profile.name
   # user_data = local.user_data
   metadata_options = {
     http_tokens = "required"

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -47,7 +47,7 @@ module "ec2_instance_1a" {
   vpc_security_group_ids = [var.application_sg, var.ssm_sg]
   subnet_id              = var.private_subnet_1a_id
   availability_zone      = var.availability_zone_1a
-  # iam_instance_profile   = var.EC2_enable_SSM_connect_role
+  iam_instance_profile   = aws_iam_role.EC2_enable_SSM_connect_role.arn
   # user_data = local.user_data
   metadata_options = {
     http_tokens = "required"
@@ -90,4 +90,24 @@ module "alb_access_log_bucket" {
   tags = {
     name = "${var.env}-alb-access-log-bucket-s3"
   }
+}
+
+resource "aws_iam_role" "EC2_enable_SSM_connect_role" {
+  name = "${var.company_name}-EC2-enable-SSM-connect-role"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "sts:AssumeRole"
+        ],
+        "Principal" : {
+          "Service" : [
+            "ec2.amazonaws.com"
+          ]
+        }
+      }
+    ]
+  })
 }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -25,6 +25,10 @@ module "alb" {
           target_id = module.ec2_instance_1a.id
           port      = 80
         }
+        my_other_target = {
+          target_id = module.ec2_instance_1c.id
+          port      = 80
+        }
       }
     }
   ]

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -48,7 +48,7 @@ module "ec2_instance_1a" {
   subnet_id              = var.private_subnet_1a_id
   availability_zone      = var.availability_zone_1a
   iam_instance_profile   = aws_iam_instance_profile.EC2_enable_SSM_connect_instance_profile.name
-  # user_data = local.user_data
+  user_data              = var.user_data
   metadata_options = {
     http_tokens = "required"
   }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -21,8 +21,10 @@ module "alb" {
       backend_port     = 80
       target_type      = "instance"
       targets = {
-        target_id = module.ec2_instance_1a.id
-        port      = 80
+        my_target = {
+          target_id = module.ec2_instance_1a.id
+          port      = 80
+        }
       }
     }
   ]

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -19,7 +19,7 @@ module "alb" {
       name             = "${var.env}-tg"
       backend_protocol = "HTTP"
       backend_port     = 80
-      target_type      = "instance"
+      target_type      = var.target_type
       targets = {
         my_target = {
           target_id = module.ec2_instance_1a.id
@@ -41,8 +41,8 @@ module "ec2_instance_1a" {
   source = "terraform-aws-modules/ec2-instance/aws"
 
   name                   = "${var.env}-ec2-instance-1a"
-  instance_type          = "t2.micro"
-  ami                    = "ami-0329eac6c5240c99d"
+  instance_type          = var.instance_type
+  ami                    = var.ami
   monitoring             = true
   vpc_security_group_ids = [var.application_sg, var.ssm_sg]
   subnet_id              = var.private_subnet_1a_id
@@ -65,7 +65,7 @@ module "ec2_instance_1a" {
 module "alb_access_log_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
   bucket = "${var.env}-alb-access-log-bucket-s3"
-  acl    = "log-delivery-write"
+  acl    = var.alb_access_log_bucket_acl
 
   # Allow deletion of non-empty bucket
   force_destroy = true

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -47,7 +47,7 @@ module "ec2_instance_1a" {
   vpc_security_group_ids = [var.application_sg, var.ssm_sg]
   subnet_id              = var.private_subnet_1a_id
   availability_zone      = var.availability_zone_1a
-  iam_instance_profile   = aws_iam_role.EC2_enable_SSM_connect_role.arn
+  iam_instance_profile   = aws_iam_instance_profile.EC2_enable_SSM_connect_instance_profile.arn
   # user_data = local.user_data
   metadata_options = {
     http_tokens = "required"
@@ -61,7 +61,6 @@ module "ec2_instance_1a" {
     Name = "${var.env}-ec2-instance-1a"
   }
 }
-
 
 module "alb_access_log_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
@@ -110,4 +109,9 @@ resource "aws_iam_role" "EC2_enable_SSM_connect_role" {
       }
     ]
   })
+}
+
+resource "aws_iam_instance_profile" "EC2_enable_SSM_connect_instance_profile" {
+  name = "${var.env}-EC2-enable-SSM-connect-instance-profile"
+  role = aws_iam_role.EC2_enable_SSM_connect_role.name
 }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -93,7 +93,7 @@ module "alb_access_log_bucket" {
 }
 
 resource "aws_iam_role" "EC2_enable_SSM_connect_role" {
-  name = "${var.company_name}-EC2-enable-SSM-connect-role"
+  name = "${var.env}-EC2-enable-SSM-connect-role"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -38,6 +38,32 @@ module "alb" {
   ]
 }
 
+module "ec2_instance_1a" {
+  source = "terraform-aws-modules/ec2-instance/aws"
+
+  name                   = "${var.env}-ec2-instance-1a"
+  instance_type          = "t2.micro"
+  ami                    = "ami-0329eac6c5240c99d"
+  monitoring             = true
+  vpc_security_group_ids = [var.application_sg, var.ssm_sg]
+  subnet_id              = var.private_subnet_1a_id
+  availability_zone      = var.availability_zone_1a
+  # iam_instance_profile   = var.EC2_enable_SSM_connect_role
+  # user_data = local.user_data
+  metadata_options = {
+    http_tokens = "required"
+  }
+
+  root_block_device = [
+    { encrypted = true }
+  ]
+
+  tags = {
+    Name = "${var.env}-ec2-instance-1a"
+  }
+}
+
+
 module "alb_access_log_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
   bucket = "${var.env}-alb-access-log-bucket-s3"

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -62,6 +62,31 @@ module "ec2_instance_1a" {
   }
 }
 
+module "ec2_instance_1c" {
+  source = "terraform-aws-modules/ec2-instance/aws"
+
+  name                   = "${var.env}-ec2-instance-1c"
+  instance_type          = var.instance_type
+  ami                    = var.ami
+  monitoring             = true
+  vpc_security_group_ids = [var.application_sg, var.ssm_sg]
+  subnet_id              = var.private_subnet_1c_id
+  availability_zone      = var.availability_zone_1c
+  iam_instance_profile   = aws_iam_instance_profile.EC2_enable_SSM_connect_instance_profile.name
+  user_data              = var.user_data
+  metadata_options = {
+    http_tokens = "required"
+  }
+
+  root_block_device = [
+    { encrypted = true }
+  ]
+
+  tags = {
+    Name = "${var.env}-ec2-instance-1c"
+  }
+}
+
 module "alb_access_log_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
   bucket = "${var.env}-alb-access-log-bucket-s3"

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -50,6 +50,14 @@ module "alb_access_log_bucket" {
   object_ownership               = "ObjectWriter"
   attach_elb_log_delivery_policy = true
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   tags = {
     name = "${var.env}-alb-access-log-bucket-s3"
   }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -1,0 +1,56 @@
+module "alb" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 8.0"
+
+  name                       = "${var.env}-alb"
+  load_balancer_type         = "application"
+  vpc_id                     = var.vpc_id
+  subnets                    = [var.public_subnet_1a_id, var.public_subnet_1c_id]
+  security_groups            = [var.alb_sg]
+  internal                   = false
+  drop_invalid_header_fields = true
+  access_logs = {
+    bucket = module.alb_access_log_bucket.s3_bucket_id
+  }
+
+
+  target_groups = [
+    {
+      name             = "${var.env}-tg"
+      backend_protocol = "HTTP"
+      backend_port     = 80
+      target_type      = "instance"
+
+      # targets = [
+      #   for ec2_instance_1a_id in var.ec2_instance_1a_ids : {
+      #     target_id = ec2_instance_1a_id
+      #     port      = var.http_port
+      #   }
+      # ]
+    }
+  ]
+  http_tcp_listeners = [
+    {
+      port               = 80
+      protocol           = "HTTP"
+      target_group_index = 0
+    }
+  ]
+}
+
+module "alb_access_log_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+  bucket = "${var.env}-alb-access-log-bucket-s3"
+  acl    = "log-delivery-write"
+
+  # Allow deletion of non-empty bucket
+  force_destroy = true
+
+  control_object_ownership       = true
+  object_ownership               = "ObjectWriter"
+  attach_elb_log_delivery_policy = true
+
+  tags = {
+    name = "${var.env}-alb-access-log-bucket-s3"
+  }
+}

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -20,13 +20,10 @@ module "alb" {
       backend_protocol = "HTTP"
       backend_port     = 80
       target_type      = "instance"
-
-      # targets = [
-      #   for ec2_instance_1a_id in var.ec2_instance_1a_ids : {
-      #     target_id = ec2_instance_1a_id
-      #     port      = var.http_port
-      #   }
-      # ]
+      targets = {
+        target_id = module.ec2_instance_1a.id
+        port      = 80
+      }
     }
   ]
   http_tcp_listeners = [

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,3 +1,8 @@
+variable "user_data" {
+  description = "The user data to provide when launching the instance"
+  type        = string
+}
+
 variable "vpc_id" {
   description = "The ID of the VPC"
   type        = string

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -43,6 +43,30 @@ variable "ssm_sg" {
   type        = string
 }
 
+variable "target_type" {
+  description = "The type of target to use"
+  type        = string
+  default     = "instance"
+}
+
+variable "instance_type" {
+  description = "The type of instance to start"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "ami" {
+  description = "The AMI to use for the instance"
+  type        = string
+  default     = "ami-0329eac6c5240c99d"
+}
+
+variable "alb_access_log_bucket_acl" {
+  description = "The canned ACL to apply"
+  type        = string
+  default     = "log-delivery-write"
+}
+
 variable "env" {
   description = "The environment to deploy to"
   type        = string

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,0 +1,25 @@
+variable "env" {
+  description = "The environment to deploy to"
+  type        = string
+  default     = "dev"
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC"
+  type        = string
+}
+
+variable "public_subnet_1a_id" {
+  description = "The ID of the public subnet in the first AZ"
+  type        = string
+}
+
+variable "public_subnet_1c_id" {
+  description = "The ID of the public subnet in the second AZ"
+  type        = string
+}
+
+variable "alb_sg" {
+  description = "The ID of the ALB security group"
+  type        = string
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,9 +1,3 @@
-variable "env" {
-  description = "The environment to deploy to"
-  type        = string
-  default     = "dev"
-}
-
 variable "vpc_id" {
   description = "The ID of the VPC"
   type        = string
@@ -19,7 +13,33 @@ variable "public_subnet_1c_id" {
   type        = string
 }
 
+variable "private_subnet_1a_id" {
+  description = "The ID of the private subnet in the first AZ"
+  type        = string
+}
+
+variable "availability_zone_1a" {
+  description = "The availability zone of the first AZ"
+  type        = string
+}
+
 variable "alb_sg" {
   description = "The ID of the ALB security group"
   type        = string
+}
+
+variable "application_sg" {
+  description = "The ID of the application security group"
+  type        = string
+}
+
+variable "ssm_sg" {
+  description = "The ID of the SSM security group"
+  type        = string
+}
+
+variable "env" {
+  description = "The environment to deploy to"
+  type        = string
+  default     = "dev"
 }

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -23,8 +23,18 @@ variable "private_subnet_1a_id" {
   type        = string
 }
 
+variable "private_subnet_1c_id" {
+  description = "The ID of the private subnet in the second AZ"
+  type        = string
+}
+
 variable "availability_zone_1a" {
   description = "The availability zone of the first AZ"
+  type        = string
+}
+
+variable "availability_zone_1c" {
+  description = "The availability zone of the second AZ"
   type        = string
 }
 

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -29,7 +29,7 @@ module "alb_sg" {
   vpc_id      = module.network.vpc_id
 
   ingress_cidr_blocks = ["0.0.0.0/0"]
-  ingress_rules       = ["https-443-tcp"]
+  ingress_rules       = ["https-443-tcp", "http-80-tcp"]
   egress_with_source_security_group_id = [
     {
       rule                     = "all-all"

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -18,9 +18,19 @@ output "private_subnet_1a_id" {
   value       = module.network.private_subnets[0]
 }
 
+output "private_subnet_1c_id" {
+  description = "The ID of the private subnet in the second AZ"
+  value       = module.network.private_subnets[1]
+}
+
 output "availability_zone_1a" {
   description = "The availability zone of the first AZ"
   value       = module.network.azs[0]
+}
+
+output "availability_zone_1c" {
+  description = "The availability zone of the second AZ"
+  value       = module.network.azs[1]
 }
 
 output "alb_sg" {

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.network.vpc_id
+}
+
+output "public_subnet_1a_id" {
+  description = "The ID of the public subnet in the first AZ"
+  value       = module.network.public_subnets[0]
+}
+
+output "public_subnet_1c_id" {
+  description = "The ID of the public subnet in the second AZ"
+  value       = module.network.public_subnets[1]
+}
+
+output "alb_sg" {
+  description = "The ID of the ALB security group"
+  value       = module.alb_sg.security_group_id
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -13,7 +13,27 @@ output "public_subnet_1c_id" {
   value       = module.network.public_subnets[1]
 }
 
+output "private_subnet_1a_id" {
+  description = "The ID of the private subnet in the first AZ"
+  value       = module.network.private_subnets[0]
+}
+
+output "availability_zone_1a" {
+  description = "The availability zone of the first AZ"
+  value       = module.network.azs[0]
+}
+
 output "alb_sg" {
   description = "The ID of the ALB security group"
   value       = module.alb_sg.security_group_id
+}
+
+output "application_sg" {
+  description = "The ID of the application security group"
+  value       = module.application_sg.security_group_id
+}
+
+output "ssm_sg" {
+  description = "The ID of the SSM security group"
+  value       = module.ssm_sg.security_group_id
 }


### PR DESCRIPTION
## 実装内容
- プライベートサブネットにEC2をそれぞれ作成
- ALBからアクセスを受ける
- IAMロールを付与
- user_dataを設定

## 作成AWSリソース
- ALB
- EC2
- IAMロール
- S3 : ALBのアクセスログを収集